### PR TITLE
Fixes and cleanups to support different use cases

### DIFF
--- a/cni_test.go
+++ b/cni_test.go
@@ -40,7 +40,10 @@ func TestLibCNIType020(t *testing.T) {
 	l.pluginConfDir = confDir
 	// Set the minimum network count as 2 for this test
 	l.networkCount = 2
-	err := l.populateNetworkConfig()
+	err := l.Load(WithDefaultConf())
+	assert.NoError(t, err)
+
+	err = l.Status()
 	assert.NoError(t, err)
 
 	mockCNI := &MockCNI{}
@@ -97,7 +100,10 @@ func TestLibCNITypeCurrent(t *testing.T) {
 	l.pluginConfDir = confDir
 	// Set the minimum network count as 2 for this test
 	l.networkCount = 2
-	err := l.populateNetworkConfig()
+	err := l.Load(WithDefaultConf())
+	assert.NoError(t, err)
+
+	err = l.Status()
 	assert.NoError(t, err)
 
 	mockCNI := &MockCNI{}

--- a/errors.go
+++ b/errors.go
@@ -10,6 +10,7 @@ var (
 	ErrNotFound          = errors.New("not found")
 	ErrRead              = errors.New("failed to read config file")
 	ErrInvalidResult     = errors.New("invalid result")
+	ErrLoad              = errors.New("failed to load cni config")
 )
 
 // IsCNINotInitialized returns true if the error is due cni config not being intialized

--- a/opts.go
+++ b/opts.go
@@ -17,21 +17,27 @@
 package cni
 
 import (
+	"sort"
+	"strings"
+
 	cnilibrary "github.com/containernetworking/cni/libcni"
+	"github.com/pkg/errors"
 )
 
-type ConfigOptions func(c *libcni) error
+type ConfigOption func(c *libcni) error
 
 // WithInterfacePrefix sets the prefix for network interfaces
 // e.g. eth or wlan
-func WithInterfacePrefix(prefix string) ConfigOptions {
+func WithInterfacePrefix(prefix string) ConfigOption {
 	return func(c *libcni) error {
 		c.prefix = prefix
 		return nil
 	}
 }
 
-func WithPluginDir(dirs []string) ConfigOptions {
+// WithPluginDir can be used to set the locations of
+// the cni plugin binaries
+func WithPluginDir(dirs []string) ConfigOption {
 	return func(c *libcni) error {
 		c.pluginDirs = dirs
 		c.cniConfig = &cnilibrary.CNIConfig{Path: dirs}
@@ -39,14 +45,33 @@ func WithPluginDir(dirs []string) ConfigOptions {
 	}
 }
 
-func WithPluginConfDir(dir string) ConfigOptions {
+// WithPluginConfDir can be used to configure the
+// cni configuration directory.
+func WithPluginConfDir(dir string) ConfigOption {
 	return func(c *libcni) error {
 		c.pluginConfDir = dir
 		return nil
 	}
 }
 
-func WithLoNetwork() ConfigOptions {
+// WithMinNetworkCount can be used to configure the
+// minimum networks to be configured and initalized
+// for the status to report success. By default its 1.
+func WithMinNetworkCount(count int) ConfigOption {
+	return func(c *libcni) error {
+		c.networkCount = count
+		return nil
+	}
+}
+
+// LoadOption can be used with Load API
+// to load network configuration from different
+// sources.
+type LoadOption func(c *libcni) error
+
+// WithLoNetwork can be used to load the loopback
+// network config.
+func WithLoNetwork() LoadOption {
 	return func(c *libcni) error {
 		loConfig, _ := cnilibrary.ConfListFromBytes([]byte(`{
 "cniVersion": "0.3.1",
@@ -55,7 +80,10 @@ func WithLoNetwork() ConfigOptions {
   "type": "loopback"
 }]
 }`))
-		c.networks = append(c.networks, &Network{
+
+		c.Lock()
+		defer c.Unlock()
+		c.networks = append(c.networks,&Network{
 			cni:    c.cniConfig,
 			config: loConfig,
 			ifName: "lo",
@@ -64,35 +92,135 @@ func WithLoNetwork() ConfigOptions {
 	}
 }
 
-func WithMinNetworkCount(count int) ConfigOptions {
+// WithConf can be used to load config directly
+// from byte.
+func WithConf(bytes []byte) LoadOption {
 	return func(c *libcni) error {
-		c.networkCount = count
+		conf, err := cnilibrary.ConfFromBytes(bytes)
+		if err != nil {
+			return err
+		}
+		confList, err := cnilibrary.ConfListFromConf(conf)
+		if err != nil {
+			return err
+		}
+		c.Lock()
+		defer c.Unlock()
+		c.networks = append(c.networks, &Network{
+			cni:    c.cniConfig,
+			config: confList,
+			ifName: getIfName(c.prefix, 0),
+		})
 		return nil
 	}
 }
 
-//TODO: Should we support direct network configs?
-/*
-func WithConf(byte []bytes) ConfigOptions {
-	return func(c *config) error {
-			c.networks=
+// WithConfFile can be used to load network config
+// from an .conf file. Supported with absolute fileName
+// with path only.
+func WithConfFile(fileName string) LoadOption {
+	return func(c *libcni) error {
+		conf, err := cnilibrary.ConfFromFile(fileName)
+		if err != nil {
+			return err
+		}
+		// upconvert to conf list
+		confList, err := cnilibrary.ConfListFromConf(conf)
+		if err != nil {
+			return err
+		}
+		c.Lock()
+		defer c.Unlock()
+		c.networks = append(c.networks, &Network{
+			cni:    c.cniConfig,
+			config: confList,
+			ifName: getIfName(c.prefix, 0),
+		})
+		return nil
 	}
 }
 
-func WithConfFile(fileName string) ConfigOptions {
-	return func(c *config) error {
-
+// WithConfListFile can be used to load network config
+// from an .conflist file. Supported with absolute fileName
+// with path only.
+func WithConfListFile(fileName string) LoadOption {
+	return func(c *libcni) error {
+		confList, err := cnilibrary.ConfListFromFile(fileName)
+		if err != nil {
+			return err
+		}
+		c.Lock()
+		defer c.Unlock()
+		c.networks = append(c.networks,&Network{
+			cni:    c.cniConfig,
+			config: confList,
+			ifName: getIfName(c.prefix, 0),
+		})
+		return nil
 	}
 }
 
-func WithConfList(byte []bytes) ConfigOptions {
-	return func(c *config) error {
-      c.
-	}
-}
-func WithConfListFile(files []string) ConfigOptions {
-	return func(c *config) error {
+// WithDefaultConf can be used to detect network config
+// files from the configured cni config directory and load
+// them.
+func WithDefaultConf() LoadOption {
+	return func(c *libcni) error {
+		files, err := cnilibrary.ConfFiles(c.pluginConfDir, []string{".conf", ".conflist", ".json"})
+		switch {
+		case err != nil:
+			return errors.Wrapf(ErrRead, "failed to read config file: %v", err)
+		case len(files) == 0:
+			return errors.Wrapf(ErrCNINotInitialized, "no network config found in %s", c.pluginConfDir)
+		}
 
+		// files contains the network config files associated with cni network.
+		// Use lexicographical way as a defined order for network config files.
+		sort.Strings(files)
+		// Since the CNI spec does not specify a way to detect default networks,
+		// the convention chosen is - the first network configuration in the sorted
+		// list of network conf files as the default network and choose the default
+		// interface provided during init as the network interface for this default
+		// network. For every other network use a generated interface id.
+		i := 0
+		c.Lock()
+		defer c.Unlock()
+		for _, confFile := range files {
+			var confList *cnilibrary.NetworkConfigList
+			if strings.HasSuffix(confFile, ".conflist") {
+				confList, err = cnilibrary.ConfListFromFile(confFile)
+				if err != nil {
+					return errors.Wrapf(ErrInvalidConfig, "failed to load CNI config list file %s: %v", confFile, err)
+				}
+			} else {
+				conf, err := cnilibrary.ConfFromFile(confFile)
+				if err != nil {
+					return errors.Wrapf(ErrInvalidConfig, "failed to load CNI config file %s: %v", confFile, err)
+				}
+				// Ensure the config has a "type" so we know what plugin to run.
+				// Also catches the case where somebody put a conflist into a conf file.
+				if conf.Network.Type == "" {
+					return errors.Wrapf(ErrInvalidConfig, "network type not found in %s", confFile)
+				}
+
+				confList, err = cnilibrary.ConfListFromConf(conf)
+				if err != nil {
+					return errors.Wrapf(ErrInvalidConfig, "failed to convert CNI config file %s to list: %v", confFile, err)
+				}
+			}
+			if len(confList.Plugins) == 0 {
+				return errors.Wrapf(ErrInvalidConfig, "CNI config list %s has no networks, skipping", confFile)
+
+			}
+			c.networks = append(c.networks, &Network{
+				cni:    c.cniConfig,
+				config: confList,
+				ifName: getIfName(c.prefix, i),
+			})
+			i++
+		}
+		if len(c.networks) == 0 {
+			return errors.Wrapf(ErrCNINotInitialized, "no valid networks found in %s", c.pluginDirs)
+		}
+		return nil
 	}
 }
-*/


### PR DESCRIPTION
1) Splitting config load from init. Added another API Load that
   loads the cni config. Added LoadOptions to load from different
   sources like .conf file,.conflist file, config as bytes in addition
   to default config from the configured cni directory
2) Added locks to protect the networks during status checks and loads
   and other parallel access.
3) Added checks for status before setup and remove actions
4) Minor clean up and test case update

Signed-off-by: abhi <abhi@docker.com>