### PR TITLE
 support loopback 0.2.0

### DIFF
--- a/namespace.go
+++ b/namespace.go
@@ -27,12 +27,27 @@ type Network struct {
 	ifName string
 }
 
+func (n *Network) isLoopback() bool {
+        for _, cfg := range n.config.Plugins {
+                if (cfg.Network.Type == "loopback") {
+                        return true
+                }
+        }
+        return false
+}
+
 func (n *Network) Attach(ns *Namespace) (*current.Result, error) {
 	r, err := n.cni.AddNetworkList(n.config, ns.config(n.ifName))
 	if err != nil {
 		return nil, err
 	}
-	return current.NewResultFromResult(r)
+	if (n.isLoopback()) {
+			return &current.Result{
+					CNIVersion: n.config.CNIVersion,
+			}, nil
+	} else {
+			return current.NewResultFromResult(r)
+	}
 }
 
 func (n *Network) Remove(ns *Namespace) error {

--- a/namespace.go
+++ b/namespace.go
@@ -28,12 +28,12 @@ type Network struct {
 }
 
 func (n *Network) isLoopback() bool {
-        for _, cfg := range n.config.Plugins {
-                if (cfg.Network.Type == "loopback") {
-                        return true
-                }
-        }
-        return false
+	for _, cfg := range n.config.Plugins {
+		if (cfg.Network.Type == "loopback") {
+			return true
+		}
+	}
+	return false
 }
 
 func (n *Network) Attach(ns *Namespace) (*current.Result, error) {
@@ -42,11 +42,11 @@ func (n *Network) Attach(ns *Namespace) (*current.Result, error) {
 		return nil, err
 	}
 	if (n.isLoopback()) {
-			return &current.Result{
-					CNIVersion: n.config.CNIVersion,
-			}, nil
+		return &current.Result{
+			CNIVersion: n.config.CNIVersion,
+		}, nil
 	} else {
-			return current.NewResultFromResult(r)
+		return current.NewResultFromResult(r)
 	}
 }
 


### PR DESCRIPTION
All conf support cniVersion 0.2.0 except type=loopback.

When loopback conf use cniVersion 0.2.0, cni interface will raise an error:
cannot convert: no valid IP addresses.

see issue https://github.com/containerd/containerd/issues/2540

Please check it, thanks.