### PR TITLE
check cniversion when use cni config content

### DIFF
--- a/opts.go
+++ b/opts.go
@@ -28,10 +28,10 @@ import (
 type CNIOpt func(c *libcni) error
 
 func checkVersion(conf *cnilibrary.NetworkConfig) bool {
+	if (conf.Network.CNIVersion == "") {
+		return (conf.Network.Type != "loopback")
+	}
 	for _, version := range cnitypes.SupportedVersions {
-		if (conf.Network.CNIVersion == "") {
-			conf.Network.CNIVersion = version
-		}
 		if (version == conf.Network.CNIVersion) {
 			return true
 		}

--- a/opts.go
+++ b/opts.go
@@ -28,10 +28,10 @@ import (
 type CNIOpt func(c *libcni) error
 
 func checkVersion(conf *cnilibrary.NetworkConfig) bool {
-	if (conf.Network.CNIVersion == "") {
-		return true
-	}
 	for _, version := range cnitypes.SupportedVersions {
+		if (conf.Network.CNIVersion == "") {
+			conf.Network.CNIVersion = version
+		}
 		if (version == conf.Network.CNIVersion) {
 			return true
 		}

--- a/opts.go
+++ b/opts.go
@@ -28,6 +28,9 @@ import (
 type CNIOpt func(c *libcni) error
 
 func checkVersion(conf *cnilibrary.NetworkConfig) bool {
+	if (conf.Network.CNIVersion == "") {
+		return true
+	}
 	for _, version := range cnitypes.SupportedVersions {
 		if (version == conf.Network.CNIVersion) {
 			return true


### PR DESCRIPTION
Signed-off-by: Lifubang <lifubang@aliyun.com>

When use cniVersion 0.2.0
All cni interface will return valid result except loopback. The error message is:
cannot convert: no valid IP addresses
Please see: https://github.com/containerd/containerd/issues/2540

I think when load default config files, we should check cniVersion.
Please check it, thanks.
