### PR TITLE
adds a get for the plugin config details

### DIFF
--- a/cni_test.go
+++ b/cni_test.go
@@ -87,6 +87,18 @@ func TestLibCNIType020(t *testing.T) {
 	assert.Equal(t, r.Interfaces["eth0"].IPConfigs[1].IP.String(), "10.0.0.2")
 	err = l.Remove("container-id1", "/proc/12345/ns/net")
 	assert.NoError(t, err)
+
+	c := l.GetConfig()
+	assert.NotNil(t, c)
+	assert.NotNil(t, c.Prefix)
+	assert.Equal(t, "eth", c.Prefix)
+	assert.NotNil(t, c.PluginDirs)
+	assert.Equal(t, DefaultCNIDir, c.PluginDirs[0])
+	assert.NotNil(t, c.PluginConfDir)
+	assert.Equal(t, confDir, c.PluginConfDir)
+	assert.NotNil(t, c.Networks)
+	assert.Equal(t, "plugin1", c.Networks[0].Config.Name)
+	assert.Equal(t, "eth0", c.Networks[0].IFName)
 }
 
 // TestLibCNITypeCurrent tests the cni version 3.x plugin


### PR DESCRIPTION
See issue https://github.com/containerd/cri/issues/979

This PR adds a get api to retrive the CNI plugin configuration information for debug / service purposes.

@Random-Liu @abhi 

Signed-off-by: Mike Brown <brownwm@us.ibm.com>