### PR TITLE
Fix some typos in comment

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -13,7 +13,7 @@ var (
 	ErrLoad              = errors.New("failed to load cni config")
 )
 
-// IsCNINotInitialized returns true if the error is due cni config not being initialized
+// IsCNINotInitialized returns true if the error is due to cni config not being initialized
 func IsCNINotInitialized(err error) bool {
 	return errors.Cause(err) == ErrCNINotInitialized
 }

--- a/errors.go
+++ b/errors.go
@@ -13,7 +13,7 @@ var (
 	ErrLoad              = errors.New("failed to load cni config")
 )
 
-// IsCNINotInitialized returns true if the error is due cni config not being intialized
+// IsCNINotInitialized returns true if the error is due cni config not being initialized
 func IsCNINotInitialized(err error) bool {
 	return errors.Cause(err) == ErrCNINotInitialized
 }

--- a/opts.go
+++ b/opts.go
@@ -55,7 +55,7 @@ func WithPluginConfDir(dir string) CNIOpt {
 }
 
 // WithMinNetworkCount can be used to configure the
-// minimum networks to be configured and initalized
+// minimum networks to be configured and initialized
 // for the status to report success. By default its 1.
 func WithMinNetworkCount(count int) CNIOpt {
 	return func(c *libcni) error {


### PR DESCRIPTION
Fix typos in comment: 
1. "intialized" to "initialized" in line 16.
2. "initalized" to "initialized" in line 58.