### PR TITLE
Avoid `Status` lockup during setup and remove.

### DIFF
--- a/result.go
+++ b/result.go
@@ -54,6 +54,9 @@ type Config struct {
 // c) DNS information. Dictionary that includes DNS information for nameservers,
 // domain, search domains and options.
 func (c *libcni) GetCNIResultFromResults(results []*current.Result) (*CNIResult, error) {
+	c.RLock()
+	defer c.RUnlock()
+
 	r := &CNIResult{
 		Interfaces: make(map[string]*Config),
 	}


### PR DESCRIPTION
For https://github.com/containerd/cri/issues/1078.

Slow `Setup` or `Remove` blocks `Status` and `Load` unnecessarily. This PR changes locking location to avoid that.

Signed-off-by: Lantao Liu <lantaol@google.com>