### PR TITLE
Add WithConfIndex opt

### DIFF
--- a/opts.go
+++ b/opts.go
@@ -86,6 +86,12 @@ func WithLoNetwork(c *libcni) error {
 // WithConf can be used to load config directly
 // from byte.
 func WithConf(bytes []byte) CNIOpt {
+	return WithConfIndex(bytes, 0)
+}
+
+// WithConfIndex can be used to load config directly
+// from byte and set the interface name's index.
+func WithConfIndex(bytes []byte, index int) CNIOpt {
 	return func(c *libcni) error {
 		conf, err := cnilibrary.ConfFromBytes(bytes)
 		if err != nil {
@@ -98,7 +104,7 @@ func WithConf(bytes []byte) CNIOpt {
 		c.networks = append(c.networks, &Network{
 			cni:    c.cniConfig,
 			config: confList,
-			ifName: getIfName(c.prefix, 0),
+			ifName: getIfName(c.prefix, index),
 		})
 		return nil
 	}


### PR DESCRIPTION
This opt allows you to provide the interface name's index with the
configuration.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>