### PR TITLE
Add support for bandwidth capability

### DIFF
--- a/namespace_opts.go
+++ b/namespace_opts.go
@@ -33,6 +33,15 @@ func WithCapabilityIPRanges(ipRanges []IPRanges) NamespaceOpts {
 	}
 }
 
+// WithCapabilityBandWitdh adds support for traffic shaping:
+// https://github.com/heptio/cni-plugins/tree/master/plugins/meta/bandwidth
+func WithCapabilityBandWidth(bandWidth BandWidth) NamespaceOpts {
+	return func(c *Namespace) error {
+		c.capabilityArgs["bandwidth"] = bandWidth
+		return nil
+	}
+}
+
 func WithCapability(name string, capability interface{}) NamespaceOpts {
 	return func(c *Namespace) error {
 		c.capabilityArgs[name] = capability

--- a/types.go
+++ b/types.go
@@ -43,3 +43,11 @@ type IPRanges struct {
 	RangeEnd   string
 	Gateway    string
 }
+
+// BandWidth defines the ingress/egress rate and burst limits
+type BandWidth struct {
+	IngressRate  int
+	IngressBurst int
+	EgressRate   int
+	EgressBurst  int
+}

--- a/types.go
+++ b/types.go
@@ -46,8 +46,8 @@ type IPRanges struct {
 
 // BandWidth defines the ingress/egress rate and burst limits
 type BandWidth struct {
-	IngressRate  int
-	IngressBurst int
-	EgressRate   int
-	EgressBurst  int
+	IngressRate  uint64
+	IngressBurst uint64
+	EgressRate   uint64
+	EgressBurst  uint64
 }


### PR DESCRIPTION
Kubernetes added support for traffic shaping (https://github.com/kubernetes/kubernetes/pull/63194/files) in order to implement traffic shaping in https://github.com/containerd/cri I wanted to add the bandwidth capalibity to the go-cni plugin.