### PR TITLE
Improve readme, golang syntax highlight

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A generic CNI library to provide APIs for CNI plugin interactions. The library p
 go-cni aims to support plugins that implement [Container Network Interface](https://github.com/containernetworking/cni)
 
 ## Usage
-```
+```go
 func main() {
 	id := "123456"
 	netns := "/proc/9999/ns/net"
@@ -24,7 +24,7 @@ func main() {
 		gocni.WithDefaultIfName(defaultIfName))
 	
 	// Load the cni configuration
-	err:= l.Load(gocni.WithLoNetwork,gocni.WithDefaultConf)
+	err:= l.Load(gocni.WithLoNetwork, gocni.WithDefaultConf)
         if err != nil{
 		log.Errorf("failed to load cni configuration: %v", err)
 		return 


### PR DESCRIPTION
1. Improve readme, make golang syntax highlight
2. Add a blank in the sample code to follow code style.