### PR TITLE
Add GoDoc to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/containerd/go-cni.svg?branch=master)](https://travis-ci.org/containerd/go-cni)
+[![Build Status](https://travis-ci.org/containerd/go-cni.svg?branch=master)](https://travis-ci.org/containerd/go-cni) [![GoDoc](https://godoc.org/github.com/containerd/go-cni?status.svg)](https://godoc.org/github.com/containerd/go-cni)
 
 # go-cni
 


### PR DESCRIPTION
This helps developers like myself with finding out what functions
and public APIs are available within the library, without checking
the code out in an IDE.

Generated from:

https://godoc.org/github.com/containerd/go-cni?tools

Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>