### PR TITLE
Added power support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ go:
   - tip
 
 go_import_path: github.com/containerd/go-cni
+arch:
+  - AMD64
+  - ppc64le
 
 install:
   - go get -d


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3.