### PR TITLE
Travis-ci: added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ go:
   - 1.13.x
   - 1.14.x
   - tip
-
+arch:
+  - AMD64
+  - ppc64le
 go_import_path: github.com/containerd/go-cni
 
 install:


### PR DESCRIPTION
Signed-off-by: Devendranath Thadi <devendranath.thadi3@gmail.com>

Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.