### PR TITLE
Move CI to use GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,85 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+
+  checks:
+    name: Project Checks
+    runs-on: ubuntu-18.04
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.16.x
+
+      - name: Set env
+        shell: bash
+        run: |
+          echo "GOPATH=${{ github.workspace }}" >> $GITHUB_ENV
+          echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
+
+      - uses: actions/checkout@v2
+        with:
+          path: src/github.com/containerd/go-cni
+          fetch-depth: 25
+
+      - uses: containerd/project-checks@v1
+        with:
+          working-directory: src/github.com/containerd/go-cni
+
+  linters:
+    name: Linters
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+
+    strategy:
+      matrix:
+        go-version: [1.16.x]
+        os: [ubuntu-18.04]
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          path: src/github.com/containerd/go-cni
+
+      - name: Set env
+        shell: bash
+        run: |
+          echo "GOPATH=${{ github.workspace }}" >> $GITHUB_ENV
+          echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
+
+      - uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.29
+          working-directory: src/github.com/containerd/go-cni
+
+  tests:
+    name: Tests
+    runs-on: ubuntu-18.04
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          path: src/github.com/containerd/go-cni
+
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.16.x
+
+      - name: Set env
+        shell: bash
+        run: |
+          echo "GOPATH=${{ github.workspace }}" >> $GITHUB_ENV
+          echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
+
+      - run: |
+          go test -v -race -covermode=atomic -coverprofile=coverage.txt  ./...
+          bash <(curl -s https://codecov.io/bash)
+        working-directory: src/github.com/containerd/go-cni

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,22 @@
+linters:
+  enable:
+    - structcheck
+    - varcheck
+    - staticcheck
+    - unconvert
+    - gofmt
+    - goimports
+    - golint
+    - ineffassign
+    - vet
+    - unused
+    - misspell
+  disable:
+    - errcheck
+
+issues:
+  include:
+    - EXC0002
+
+run:
+  timeout: 2m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,9 +14,10 @@ linters:
   disable:
     - errcheck
 
-issues:
-  include:
-    - EXC0002
+# FIXME: re-enable after fixing GoDoc in this repository
+#issues:
+#  include:
+#    - EXC0002
 
 run:
   timeout: 2m

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
-[![Build Status](https://travis-ci.org/containerd/go-cni.svg?branch=master)](https://travis-ci.org/containerd/go-cni) [![GoDoc](https://godoc.org/github.com/containerd/go-cni?status.svg)](https://godoc.org/github.com/containerd/go-cni)
-
 # go-cni
+
+[![PkgGoDev](https://pkg.go.dev/badge/github.com/containerd/go-cni)](https://pkg.go.dev/github.com/containerd/go-cni)
+[![Build Status](https://github.com/containerd/go-cni/workflows/CI/badge.svg)](https://github.com/containerd/go-cni/actions?query=workflow%3ACI)
+[![codecov](https://codecov.io/gh/containerd/go-cni/branch/master/graph/badge.svg)](https://codecov.io/gh/containerd/go-cni)
+[![Go Report Card](https://goreportcard.com/badge/github.com/containerd/go-cni)](https://goreportcard.com/report/github.com/containerd/go-cni)
 
 A generic CNI library to provide APIs for CNI plugin interactions. The library provides APIs to:
 

--- a/cni_test.go
+++ b/cni_test.go
@@ -125,6 +125,7 @@ func TestLibCNITypeCurrent(t *testing.T) {
 	l.networks[0].cni = mockCNI
 	l.networks[1].cni = mockCNI
 	ipv4, err := types.ParseCIDR("10.0.0.1/24")
+	assert.NoError(t, err)
 	expectedRT := &cnilibrary.RuntimeConf{
 		ContainerID:    "container-id1",
 		NetNS:          "/proc/12345/ns/net",
@@ -151,6 +152,7 @@ func TestLibCNITypeCurrent(t *testing.T) {
 	mockCNI.On("DelNetworkList", l.networks[0].config, expectedRT).Return(nil)
 
 	ipv4, err = types.ParseCIDR("10.0.0.2/24")
+	assert.NoError(t, err)
 	l.networks[1].cni = mockCNI
 	expectedRT = &cnilibrary.RuntimeConf{
 		ContainerID:    "container-id1",

--- a/opts.go
+++ b/opts.go
@@ -24,7 +24,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-type CNIOpt func(c *libcni) error
+type CNIOpt func(c *libcni) error //nolint: golint // type name will be used as cni.CNIOpt by other packages, and that stutters; consider calling this Opt
 
 // WithInterfacePrefix sets the prefix for network interfaces
 // e.g. eth or wlan

--- a/result.go
+++ b/result.go
@@ -29,6 +29,7 @@ type IPConfig struct {
 	Gateway net.IP
 }
 
+//nolint: golint // type name will be used as cni.CNIResult by other packages, and that stutters; consider calling this Result
 type CNIResult struct {
 	Interfaces map[string]*Config
 	DNS        []types.DNS


### PR DESCRIPTION
obsoletes https://github.com/containerd/go-cni/pull/61