### PR TITLE
Rename/deprecate CNIOpt, CNIResult, CNI.GetCNIResultFromResults

### DIFF
--- a/cni.go
+++ b/cni.go
@@ -139,7 +139,7 @@ func (c *libcni) Networks() []*Network {
 	return append([]*Network{}, c.networks...)
 }
 
-// Setup setups the network in the namespace
+// Setup setups the network in the namespace and returns a Result
 func (c *libcni) Setup(ctx context.Context, id string, path string, opts ...NamespaceOpts) (*Result, error) {
 	if err := c.Status(); err != nil {
 		return nil, err
@@ -148,6 +148,14 @@ func (c *libcni) Setup(ctx context.Context, id string, path string, opts ...Name
 	if err != nil {
 		return nil, err
 	}
+	result, err := c.attachNetworks(ctx, ns)
+	if err != nil {
+		return nil, err
+	}
+	return c.createResult(result)
+}
+
+func (c *libcni) attachNetworks(ctx context.Context, ns *Namespace) ([]*current.Result, error) {
 	var results []*current.Result
 	for _, network := range c.Networks() {
 		r, err := network.Attach(ctx, ns)
@@ -156,7 +164,7 @@ func (c *libcni) Setup(ctx context.Context, id string, path string, opts ...Name
 		}
 		results = append(results, r)
 	}
-	return c.GetCNIResultFromResults(results)
+	return results, nil
 }
 
 // Remove removes the network config from the namespace

--- a/cni.go
+++ b/cni.go
@@ -30,11 +30,11 @@ import (
 
 type CNI interface {
 	// Setup setup the network for the namespace
-	Setup(ctx context.Context, id string, path string, opts ...NamespaceOpts) (*CNIResult, error)
+	Setup(ctx context.Context, id string, path string, opts ...NamespaceOpts) (*Result, error)
 	// Remove tears down the network of the namespace.
 	Remove(ctx context.Context, id string, path string, opts ...NamespaceOpts) error
 	// Load loads the cni network config
-	Load(opts ...CNIOpt) error
+	Load(opts ...Opt) error
 	// Status checks the status of the cni initialization
 	Status() error
 	// GetConfig returns a copy of the CNI plugin configurations as parsed by CNI
@@ -93,7 +93,7 @@ func defaultCNIConfig() *libcni {
 }
 
 // New creates a new libcni instance.
-func New(config ...CNIOpt) (CNI, error) {
+func New(config ...Opt) (CNI, error) {
 	cni := defaultCNIConfig()
 	var err error
 	for _, c := range config {
@@ -105,7 +105,7 @@ func New(config ...CNIOpt) (CNI, error) {
 }
 
 // Load loads the latest config from cni config files.
-func (c *libcni) Load(opts ...CNIOpt) error {
+func (c *libcni) Load(opts ...Opt) error {
 	var err error
 	c.Lock()
 	defer c.Unlock()
@@ -140,7 +140,7 @@ func (c *libcni) Networks() []*Network {
 }
 
 // Setup setups the network in the namespace
-func (c *libcni) Setup(ctx context.Context, id string, path string, opts ...NamespaceOpts) (*CNIResult, error) {
+func (c *libcni) Setup(ctx context.Context, id string, path string, opts ...NamespaceOpts) (*Result, error) {
 	if err := c.Status(); err != nil {
 		return nil, err
 	}

--- a/deprecated.go
+++ b/deprecated.go
@@ -1,0 +1,34 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package cni
+
+import "github.com/containernetworking/cni/pkg/types/current"
+
+// Deprecated: use cni.Opt instead
+type CNIOpt = Opt //nolint: golint // type name will be used as cni.CNIOpt by other packages, and that stutters
+
+// Deprecated: use cni.Result instead
+type CNIResult = Result //nolint: golint // type name will be used as cni.CNIResult by other packages, and that stutters
+
+// GetCNIResultFromResults creates a Result from the given slice of current.Result,
+// adding structured data containing the interface configuration for each of the
+// interfaces created in the namespace. It returns an error if validation of
+// results fails, or if a network could not be found.
+// Deprecated: do not use
+func (c *libcni) GetCNIResultFromResults(results []*current.Result) (*Result, error) {
+	return c.createResult(results)
+}

--- a/opts.go
+++ b/opts.go
@@ -24,9 +24,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-// Deprecated: use cni.Opt instead
-type CNIOpt = Opt //nolint: golint // type name will be used as cni.CNIOpt by other packages, and that stutters
-
 // Opt sets options for a CNI instance
 type Opt func(c *libcni) error
 

--- a/opts.go
+++ b/opts.go
@@ -24,11 +24,15 @@ import (
 	"github.com/pkg/errors"
 )
 
-type CNIOpt func(c *libcni) error //nolint: golint // type name will be used as cni.CNIOpt by other packages, and that stutters; consider calling this Opt
+// Deprecated: use cni.Opt instead
+type CNIOpt = Opt //nolint: golint // type name will be used as cni.CNIOpt by other packages, and that stutters
+
+// Opt sets options for a CNI instance
+type Opt func(c *libcni) error
 
 // WithInterfacePrefix sets the prefix for network interfaces
 // e.g. eth or wlan
-func WithInterfacePrefix(prefix string) CNIOpt {
+func WithInterfacePrefix(prefix string) Opt {
 	return func(c *libcni) error {
 		c.prefix = prefix
 		return nil
@@ -37,7 +41,7 @@ func WithInterfacePrefix(prefix string) CNIOpt {
 
 // WithPluginDir can be used to set the locations of
 // the cni plugin binaries
-func WithPluginDir(dirs []string) CNIOpt {
+func WithPluginDir(dirs []string) Opt {
 	return func(c *libcni) error {
 		c.pluginDirs = dirs
 		c.cniConfig = &cnilibrary.CNIConfig{Path: dirs}
@@ -47,7 +51,7 @@ func WithPluginDir(dirs []string) CNIOpt {
 
 // WithPluginConfDir can be used to configure the
 // cni configuration directory.
-func WithPluginConfDir(dir string) CNIOpt {
+func WithPluginConfDir(dir string) Opt {
 	return func(c *libcni) error {
 		c.pluginConfDir = dir
 		return nil
@@ -56,7 +60,7 @@ func WithPluginConfDir(dir string) CNIOpt {
 
 // WithPluginMaxConfNum can be used to configure the
 // max cni plugin config file num.
-func WithPluginMaxConfNum(max int) CNIOpt {
+func WithPluginMaxConfNum(max int) Opt {
 	return func(c *libcni) error {
 		c.pluginMaxConfNum = max
 		return nil
@@ -66,7 +70,7 @@ func WithPluginMaxConfNum(max int) CNIOpt {
 // WithMinNetworkCount can be used to configure the
 // minimum networks to be configured and initialized
 // for the status to report success. By default its 1.
-func WithMinNetworkCount(count int) CNIOpt {
+func WithMinNetworkCount(count int) Opt {
 	return func(c *libcni) error {
 		c.networkCount = count
 		return nil
@@ -94,13 +98,13 @@ func WithLoNetwork(c *libcni) error {
 
 // WithConf can be used to load config directly
 // from byte.
-func WithConf(bytes []byte) CNIOpt {
+func WithConf(bytes []byte) Opt {
 	return WithConfIndex(bytes, 0)
 }
 
 // WithConfIndex can be used to load config directly
 // from byte and set the interface name's index.
-func WithConfIndex(bytes []byte, index int) CNIOpt {
+func WithConfIndex(bytes []byte, index int) Opt {
 	return func(c *libcni) error {
 		conf, err := cnilibrary.ConfFromBytes(bytes)
 		if err != nil {
@@ -122,7 +126,7 @@ func WithConfIndex(bytes []byte, index int) CNIOpt {
 // WithConfFile can be used to load network config
 // from an .conf file. Supported with absolute fileName
 // with path only.
-func WithConfFile(fileName string) CNIOpt {
+func WithConfFile(fileName string) Opt {
 	return func(c *libcni) error {
 		conf, err := cnilibrary.ConfFromFile(fileName)
 		if err != nil {
@@ -144,7 +148,7 @@ func WithConfFile(fileName string) CNIOpt {
 
 // WithConfListBytes can be used to load network config list directly
 // from byte
-func WithConfListBytes(bytes []byte) CNIOpt {
+func WithConfListBytes(bytes []byte) Opt {
 	return func(c *libcni) error {
 		confList, err := cnilibrary.ConfListFromBytes(bytes)
 		if err != nil {
@@ -163,7 +167,7 @@ func WithConfListBytes(bytes []byte) CNIOpt {
 // WithConfListFile can be used to load network config
 // from an .conflist file. Supported with absolute fileName
 // with path only.
-func WithConfListFile(fileName string) CNIOpt {
+func WithConfListFile(fileName string) Opt {
 	return func(c *libcni) error {
 		confList, err := cnilibrary.ConfListFromFile(fileName)
 		if err != nil {

--- a/result.go
+++ b/result.go
@@ -29,8 +29,10 @@ type IPConfig struct {
 	Gateway net.IP
 }
 
-//nolint: golint // type name will be used as cni.CNIResult by other packages, and that stutters; consider calling this Result
-type CNIResult struct {
+// Deprecated: use cni.Result instead
+type CNIResult = Result //nolint: golint // type name will be used as cni.CNIResult by other packages, and that stutters
+
+type Result struct {
 	Interfaces map[string]*Config
 	DNS        []types.DNS
 	Routes     []*types.Route
@@ -54,11 +56,11 @@ type Config struct {
 // gateways, and routes assigned to sandbox and/or host interfaces.
 // c) DNS information. Dictionary that includes DNS information for nameservers,
 // domain, search domains and options.
-func (c *libcni) GetCNIResultFromResults(results []*current.Result) (*CNIResult, error) {
+func (c *libcni) GetCNIResultFromResults(results []*current.Result) (*Result, error) {
 	c.RLock()
 	defer c.RUnlock()
 
-	r := &CNIResult{
+	r := &Result{
 		Interfaces: make(map[string]*Config),
 	}
 

--- a/result.go
+++ b/result.go
@@ -29,9 +29,16 @@ type IPConfig struct {
 	Gateway net.IP
 }
 
-// Deprecated: use cni.Result instead
-type CNIResult = Result //nolint: golint // type name will be used as cni.CNIResult by other packages, and that stutters
-
+// Result contains the network information returned by CNI.Setup
+//
+// a) Interfaces list. Depending on the plugin, this can include the sandbox
+//    (eg, container or hypervisor) interface name and/or the host interface
+//    name, the hardware addresses of each interface, and details about the
+//    sandbox (if any) the interface is in.
+// b) IP configuration assigned to each  interface. The IPv4 and/or IPv6 addresses,
+//    gateways, and routes assigned to sandbox and/or host interfaces.
+// c) DNS information. Dictionary that includes DNS information for nameservers,
+//     domain, search domains and options.
 type Result struct {
 	Interfaces map[string]*Config
 	DNS        []types.DNS
@@ -44,22 +51,13 @@ type Config struct {
 	Sandbox   string
 }
 
-// GetCNIResultFromResults returns a structured data containing the
-// interface configuration for each of the interfaces created in the namespace.
-// Conforms with
-// Result:
-// a) Interfaces list. Depending on the plugin, this can include the sandbox
-// (eg, container or hypervisor) interface name and/or the host interface
-// name, the hardware addresses of each interface, and details about the
-// sandbox (if any) the interface is in.
-// b) IP configuration assigned to each  interface. The IPv4 and/or IPv6 addresses,
-// gateways, and routes assigned to sandbox and/or host interfaces.
-// c) DNS information. Dictionary that includes DNS information for nameservers,
-// domain, search domains and options.
-func (c *libcni) GetCNIResultFromResults(results []*current.Result) (*Result, error) {
+// createResult creates a Result from the given slice of current.Result, adding
+// structured data containing the interface configuration for each of the
+// interfaces created in the namespace. It returns an error if validation of
+// results fails, or if a network could not be found.
+func (c *libcni) createResult(results []*current.Result) (*Result, error) {
 	c.RLock()
 	defer c.RUnlock()
-
 	r := &Result{
 		Interfaces: make(map[string]*Config),
 	}


### PR DESCRIPTION
follow-up to https://github.com/containerd/go-cni/pull/63

To address golint;

    opts.go:27:6: type name will be used as cni.CNIOpt by other packages, and that stutters; consider calling this Opt (golint)
    type CNIOpt func(c *libcni) error
         ^
    result.go:32:6: type name will be used as cni.CNIResult by other packages, and that stutters; consider calling this Result (golint)
    type CNIResult struct {
         ^

The old names are kept for backward compatiblity (as this module is already past v1.0.0)