### PR TITLE
result: expose raw result

### DIFF
--- a/result.go
+++ b/result.go
@@ -39,10 +39,12 @@ type IPConfig struct {
 //    gateways, and routes assigned to sandbox and/or host interfaces.
 // c) DNS information. Dictionary that includes DNS information for nameservers,
 //     domain, search domains and options.
+// d) Raw CNI results
 type Result struct {
 	Interfaces map[string]*Config
 	DNS        []types.DNS
 	Routes     []*types.Route
+	Raw        []*current.Result
 }
 
 type Config struct {
@@ -60,6 +62,7 @@ func (c *libcni) createResult(results []*current.Result) (*Result, error) {
 	defer c.RUnlock()
 	r := &Result{
 		Interfaces: make(map[string]*Config),
+		Raw:        results,
 	}
 
 	// Plugins may not need to return Interfaces in result if


### PR DESCRIPTION
- gocni.Result: results of multiple networks are mixed up
- gocni.Result.Raw (new): the raw results of multiple networks, without mixing up

Will be used for multi-networking support of nerdctl. (https://github.com/containerd/nerdctl/pull/189)
