### PR TITLE
remove: Continue on "not found" errors

### DIFF
--- a/cni.go
+++ b/cni.go
@@ -183,7 +183,9 @@ func (c *libcni) Remove(ctx context.Context, id string, path string, opts ...Nam
 			// https://github.com/containernetworking/plugins/issues/210
 			// TODO(random-liu): Remove the error handling when the issue is
 			// fixed and the CNI spec v0.6.0 support is deprecated.
-			if path == "" && strings.Contains(err.Error(), "no such file or directory") {
+			// NOTE(claudiub): Some CNIs could return a "not found" error, which could mean that
+			// it was already deleted.
+			if (path == "" && strings.Contains(err.Error(), "no such file or directory")) || strings.Contains(err.Error(), "not found") {
 				continue
 			}
 			return err


### PR DESCRIPTION
Some CNIs might return a "not found" error when removing an Endpoint / path, which means that it was already removed. We can continue in this case; this will mean that containerd will be able to forcefully remove Pods in this state.

Related: https://github.com/containerd/containerd/issues/6135

Signed-off-by: Claudiu Belu <cbelu@cloudbasesolutions.com>