### PR TITLE
Fix dead link for bandwidth plugin comment

### DIFF
--- a/namespace_opts.go
+++ b/namespace_opts.go
@@ -34,7 +34,7 @@ func WithCapabilityIPRanges(ipRanges []IPRanges) NamespaceOpts {
 }
 
 // WithCapabilityBandWitdh adds support for traffic shaping:
-// https://github.com/heptio/cni-plugins/tree/master/plugins/meta/bandwidth
+// https://github.com/containernetworking/plugins/tree/master/plugins/meta/bandwidth
 func WithCapabilityBandWidth(bandWidth BandWidth) NamespaceOpts {
 	return func(c *Namespace) error {
 		c.capabilityArgs["bandwidth"] = bandWidth


### PR DESCRIPTION
Resolving a dead link for the bandwidth plugin. 

Resolves Issue:
https://github.com/containerd/go-cni/issues/78