### PR TITLE
Fix issue with old cni version on loopback

### DIFF
--- a/opts.go
+++ b/opts.go
@@ -87,7 +87,7 @@ func WithMinNetworkCount(count int) Opt {
 // network config.
 func WithLoNetwork(c *libcni) error {
 	loConfig, _ := cnilibrary.ConfListFromBytes([]byte(`{
-"cniVersion": "0.3.1",
+"cniVersion": "0.4.0",
 "name": "cni-loopback",
 "plugins": [{
   "type": "loopback"


### PR DESCRIPTION
When adding the Check method after the Add method is called in runpodsandbox, I found that my previous PR missed this. 

Signed-off-by: Michael Zappa <Michael.Zappa@stateless.net>