### PR TITLE
Use revive instead of golint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
 
       - uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.29
+          version: v1.45.2
           working-directory: src/github.com/containerd/go-cni
 
   tests:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,7 +6,7 @@ linters:
     - unconvert
     - gofmt
     - goimports
-    - golint
+    - revive
     - ineffassign
     - vet
     - unused

--- a/deprecated.go
+++ b/deprecated.go
@@ -19,10 +19,10 @@ package cni
 import types100 "github.com/containernetworking/cni/pkg/types/100"
 
 // Deprecated: use cni.Opt instead
-type CNIOpt = Opt //nolint: golint // type name will be used as cni.CNIOpt by other packages, and that stutters
+type CNIOpt = Opt //revive:disable // type name will be used as cni.CNIOpt by other packages, and that stutters
 
 // Deprecated: use cni.Result instead
-type CNIResult = Result //nolint: golint // type name will be used as cni.CNIResult by other packages, and that stutters
+type CNIResult = Result //revive:disable // type name will be used as cni.CNIResult by other packages, and that stutters
 
 // GetCNIResultFromResults creates a Result from the given slice of types100.Result,
 // adding structured data containing the interface configuration for each of the


### PR DESCRIPTION
Signed-off-by: Wang Bing <wangbing.adam@gmail.com>

The linter 'golint' is deprecated (since v1.41.0).ref: https://github.com/golangci/golangci-lint/issues/1892