### PR TITLE
add in some serial setup tests; a little make cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,8 +89,7 @@ jobs:
 
       - run: |
           bash -x script/install-cni
-          make clean V=1
-          make bin/integration.test V=1
+          sudo make clean V=1
           make test V=1
           sudo make integration V=1
         working-directory: src/github.com/containerd/go-cni

--- a/Makefile
+++ b/Makefile
@@ -31,12 +31,10 @@ help: ## this help
 test: ## run tests, except integration tests and tests that require root
 	$(Q)go test -v -race $(EXTRA_TESTFLAGS) -count=1 ./...
 
-integration: ## run integration test
+integration: bin/integration.test ## run integration test
 	$(Q)bin/integration.test -test.v -test.count=1 -test.root $(EXTRA_TESTFLAGS) -test.parallel $(TESTFLAGS_PARALLEL)
 
-FORCE:
-
-bin/integration.test: FORCE ## build integration test binary into bin
+bin/integration.test: ## build integration test binary into bin
 	$(Q)cd ./integration && go test -race -c . -o ../bin/integration.test
 
 clean: ## clean up binaries

--- a/integration/cni_setup_teardown_linux_test.go
+++ b/integration/cni_setup_teardown_linux_test.go
@@ -198,14 +198,26 @@ func TestBasicSetupAndRemove(t *testing.T) {
 
 		// Setup network
 		result, err := l.Setup(ctx, id, nsPath)
-		assert.NoError(t, err, "[%v] setup network for namespace %v", idx, nsPath)
+		assert.NoError(t, err, "[%v] setup network interfaces for namespace in parallel %v", idx, nsPath)
 
 		ip := result.Interfaces[defaultIfName].IPConfigs[0].IP.String()
 		t.Logf("[%v] ip is %v", idx, ip)
 
 		assert.NoError(t,
 			l.Remove(ctx, id, nsPath),
-			"[%v] teardown network for namespace %v", idx, nsPath,
+			"[%v] teardown network interfaces for namespace %v", idx, nsPath,
+		)
+
+		// Setup network serially
+		result, err = l.SetupSerially(ctx, id, nsPath)
+		assert.NoError(t, err, "[%v] setup network interfaces for namespace serially%v", idx, nsPath)
+
+		ip = result.Interfaces[defaultIfName].IPConfigs[0].IP.String()
+		t.Logf("[%v] ip is %v", idx, ip)
+
+		assert.NoError(t,
+			l.Remove(ctx, id, nsPath),
+			"[%v] teardown network interfaces for namespace %v", idx, nsPath,
 		)
 	}
 }
@@ -271,14 +283,26 @@ func TestBasicSetupAndRemovePluginWithoutVersion(t *testing.T) {
 
 		// Setup network
 		result, err := l.Setup(ctx, id, nsPath)
-		assert.NoError(t, err, "[%v] setup network for namespace %v", idx, nsPath)
+		assert.NoError(t, err, "[%v] setup network interfaces for namespace in parallel %v", idx, nsPath)
 
 		ip := result.Interfaces[defaultIfName].IPConfigs[0].IP.String()
 		t.Logf("[%v] ip is %v", idx, ip)
 
 		assert.NoError(t,
 			l.Remove(ctx, id, nsPath),
-			"[%v] teardown network for namespace %v", idx, nsPath,
+			"[%v] teardown network interfaces for namespace %v", idx, nsPath,
+		)
+
+		// Setup network serially
+		result, err = l.SetupSerially(ctx, id, nsPath)
+		assert.NoError(t, err, "[%v] setup network interfaces for namespace serially%v", idx, nsPath)
+
+		ip = result.Interfaces[defaultIfName].IPConfigs[0].IP.String()
+		t.Logf("[%v] ip is %v", idx, ip)
+
+		assert.NoError(t,
+			l.Remove(ctx, id, nsPath),
+			"[%v] teardown network interfaces for namespace %v", idx, nsPath,
 		)
 	}
 }


### PR DESCRIPTION
A follow up on https://github.com/containerd/go-cni/pull/99 to add in some serial setup buckets..

Also made a couple nits to the makefile..

Signed-off-by: Mike Brown <brownwm@us.ibm.com>