### PR TITLE
Remove references to io/ioutil package

### DIFF
--- a/integration/cni_setup_teardown_linux_test.go
+++ b/integration/cni_setup_teardown_linux_test.go
@@ -35,7 +35,6 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"runtime"
@@ -146,7 +145,7 @@ func TestBasicSetupAndRemove(t *testing.T) {
 	defer os.RemoveAll(tmpPluginConfDir)
 
 	assert.NoError(t,
-		ioutil.WriteFile(
+		os.WriteFile(
 			path.Join(tmpPluginConfDir, "10-gocni-test-net.conflist"),
 			[]byte(cniBridgePluginCfg),
 			0600,
@@ -231,7 +230,7 @@ func TestBasicSetupAndRemovePluginWithoutVersion(t *testing.T) {
 	defer os.RemoveAll(tmpPluginConfDir)
 
 	assert.NoError(t,
-		ioutil.WriteFile(
+		os.WriteFile(
 			path.Join(tmpPluginConfDir, "10-gocni-test-net.conflist"),
 			[]byte(cniBridgePluginCfgWithoutVersion),
 			0600,

--- a/testutils.go
+++ b/testutils.go
@@ -18,14 +18,13 @@ package cni
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
 )
 
 func makeTmpDir(prefix string) (string, error) {
-	tmpDir, err := ioutil.TempDir(os.TempDir(), prefix)
+	tmpDir, err := os.MkdirTemp("", prefix)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
io/ioutil has been marked deprecated in Go 1.16.

Signed-off-by: Austin Vazquez <macedonv@amazon.com>