### PR TITLE
Update golangci/golangci-lint package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
 
       - uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.45.2
+          version: v1.50.1
           working-directory: src/github.com/containerd/go-cni
 
   tests:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,5 @@
 linters:
   enable:
-    - structcheck
-    - varcheck
     - staticcheck
     - unconvert
     - gofmt

--- a/result.go
+++ b/result.go
@@ -32,13 +32,18 @@ type IPConfig struct {
 // Result contains the network information returned by CNI.Setup
 //
 // a) Interfaces list. Depending on the plugin, this can include the sandbox
-//    (eg, container or hypervisor) interface name and/or the host interface
-//    name, the hardware addresses of each interface, and details about the
-//    sandbox (if any) the interface is in.
+//
+//	(eg, container or hypervisor) interface name and/or the host interface
+//	name, the hardware addresses of each interface, and details about the
+//	sandbox (if any) the interface is in.
+//
 // b) IP configuration assigned to each  interface. The IPv4 and/or IPv6 addresses,
-//    gateways, and routes assigned to sandbox and/or host interfaces.
+//
+//	gateways, and routes assigned to sandbox and/or host interfaces.
+//
 // c) DNS information. Dictionary that includes DNS information for nameservers,
-//     domain, search domains and options.
+//
+//	domain, search domains and options.
 type Result struct {
 	Interfaces map[string]*Config
 	DNS        []types.DNS


### PR DESCRIPTION
Update golanci/golangci-lint package from v1.45.2 to v1.50.1. Run go fmt on package.
Remove deprecated linters.

Signed-off-by: Austin Vazquez <macedonv@amazon.com>