### PR TITLE
opts: add cgroupPath capability

### DIFF
--- a/namespace_opts.go
+++ b/namespace_opts.go
@@ -50,6 +50,14 @@ func WithCapabilityDNS(dns DNS) NamespaceOpts {
 	}
 }
 
+// WithCapabilityCgroupPath passes in the cgroup path capability.
+func WithCapabilityCgroupPath(cgroupPath string) NamespaceOpts {
+	return func(c *Namespace) error {
+		c.capabilityArgs["cgroupPath"] = cgroupPath
+		return nil
+	}
+}
+
 // WithCapability support well-known capabilities
 // https://www.cni.dev/docs/conventions/#well-known-capabilities
 func WithCapability(name string, capability interface{}) NamespaceOpts {


### PR DESCRIPTION
There is a new capability arg, cgroupPath, which is the relative cgroup path of the container.

Ref: https://github.com/containernetworking/cni/pull/936

Signed-off-by: Casey Callendrello <cdc@isovalent.com>