### PR TITLE
Add Go 1.20 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.17.x
+          go-version: 1.20.x
 
       - name: Set env
         shell: bash
@@ -29,11 +29,11 @@ jobs:
           path: src/github.com/containerd/go-cni
           fetch-depth: 25
 
-      - uses: containerd/project-checks@v1
+      - uses: containerd/project-checks@v1.1.0
         with:
           working-directory: src/github.com/containerd/go-cni
 
-      - uses: containerd/project-checks@v1
+      - uses: containerd/project-checks@v1.1.0
         with:
           working-directory: src/github.com/containerd/go-cni/integration
 
@@ -44,7 +44,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: [1.17.x]
+        go-version: [1.19.x, 1.20.x]
         os: [ubuntu-22.04]
 
     steps:
@@ -64,13 +64,17 @@ jobs:
 
       - uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.50.1
+          version: v1.51.1
           working-directory: src/github.com/containerd/go-cni
 
   tests:
     name: Tests
     runs-on: ubuntu-22.04
     timeout-minutes: 5
+
+    strategy:
+      matrix:
+        go-version: [1.19.x, 1.20.x]
 
     steps:
       - uses: actions/checkout@v3
@@ -79,7 +83,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.17.x
+          go-version: ${{ matrix.go }}
 
       - name: Set env
         shell: bash

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/containerd/go-cni
 
-go 1.17
+go 1.19
 
 require (
 	github.com/containernetworking/cni v1.1.2


### PR DESCRIPTION
Updates containerd/project-checks to v1.1.0 to run with Go 1.20. Updates
golangci/golangci-lint to v1.51.1 for Go 1.20 support. Adds Go 1.20 to
lint and test steps. Bumps minimum required version to Go 1.19

Signed-off-by: Austin Vazquez <macedonv@amazon.com>