### PR TITLE
Bump github actions dependencies to match containerd CI repo and fix lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
           go-version: 1.21.x
 
@@ -24,7 +24,7 @@ jobs:
           echo "GOPATH=${{ github.workspace }}" >> $GITHUB_ENV
           echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           path: src/github.com/containerd/go-cni
           fetch-depth: 25
@@ -48,11 +48,11 @@ jobs:
         os: [ubuntu-22.04]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           path: src/github.com/containerd/go-cni
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
 
@@ -62,9 +62,9 @@ jobs:
           echo "GOPATH=${{ github.workspace }}" >> $GITHUB_ENV
           echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
 
-      - uses: golangci/golangci-lint-action@v3
+      - uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.56.1
+          version: v1.61.0
           working-directory: src/github.com/containerd/go-cni
 
   tests:
@@ -76,12 +76,12 @@ jobs:
       matrix:
         go-version: ["1.21.8", "1.22.1"]
 
-    steps:
-      - uses: actions/checkout@v3
+      steps:
+      - uses: actions/checkout@v4
         with:
           path: src/github.com/containerd/go-cni
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
       matrix:
         go-version: ["1.21.8", "1.22.1"]
 
-      steps:
+    steps:
       - uses: actions/checkout@v4
         with:
           path: src/github.com/containerd/go-cni

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A generic CNI library to provide APIs for CNI plugin interactions. The library p
 - Query status of CNI network plugin initialization
 - Check verifies the network is still in desired state
 
-go-cni aims to support plugins that implement [Container Network Interface](https://github.com/containernetworking/cni)
+go-cni aims to support plugins that implement [Container Network Interface](https://github.com/containernetworking/cni).
 
 ## Usage
 ```go

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A generic CNI library to provide APIs for CNI plugin interactions. The library p
 - Query status of CNI network plugin initialization
 - Check verifies the network is still in desired state
 
-go-cni aims to support plugins that implement [Container Network Interface](https://github.com/containernetworking/cni).
+go-cni aims to support plugins that implement the [Container Network Interface](https://github.com/containernetworking/cni).
 
 ## Usage
 ```go


### PR DESCRIPTION
Currently CI is broken with lint failures, as proved by trivial doc commits, for example https://github.com/containerd/go-cni/actions/runs/11523576454/job/32081885304

This PR updates the `setup-go`, `checkout` and `golangci-lint-action` versions to match those in the containerd repo. This fixes the issue.