### PR TITLE
Add WithPluginDirsAndCacheDir option and deprecate WithPluginDir option

### DIFF
--- a/opts.go
+++ b/opts.go
@@ -39,8 +39,27 @@ func WithInterfacePrefix(prefix string) Opt {
 	}
 }
 
+// WithPluginDirsAndCacheDir can be used to set the locations of
+// the cni plugin binaries and cni cache dir
+// cacheDir: to use default provided in libcni set value to empty string
+func WithPluginDirsAndCacheDir(pluginDirs []string, cacheDir string) Opt {
+	return func(c *libcni) error {
+		c.pluginDirs = pluginDirs
+		c.cniConfig = cnilibrary.NewCNIConfigWithCacheDir(
+			pluginDirs,
+			cacheDir,
+			&invoke.DefaultExec{
+				RawExec:       &invoke.RawExec{Stderr: os.Stderr},
+				PluginDecoder: version.PluginDecoder{},
+			},
+		)
+		return nil
+	}
+}
+
 // WithPluginDir can be used to set the locations of
 // the cni plugin binaries
+// Deprecated: use WithPluginDirsAndCacheDir instead
 func WithPluginDir(dirs []string) Opt {
 	return func(c *libcni) error {
 		c.pluginDirs = dirs


### PR DESCRIPTION
Right now there is no way to configure cni cache directory from containerd, libcni already upstreamed ability to configure it through new CNIConfig constructor function NewCNIConfigWithCacheDir. If we want same behavior as before, we can just set cacheDir argument to empty string as I noted in documentation string before WithPluginDirsAndCacheDir function.
This change would allow containerd to then set this cache dir from configuration file.