### PR TITLE
README: document default CNI paths and non-standard setup guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,21 @@ func main() {
 }
 ```
 
+## Defaults
+
+`go-cni` has built-in defaults when `WithPluginDir` / `WithPluginConfDir` are not set:
+
+- non-Windows:
+  - plugin dir: `/opt/cni/bin`
+  - config dir: `/etc/cni/net.d`
+- Windows:
+  - plugin dir: `C:\Program Files\containerd\cni\bin`
+  - config dir: `C:\Program Files\containerd\cni\conf`
+
+For rootless or non-standard environments (for example Darwin-based setups),
+pass explicit directories via `WithPluginDir` and `WithPluginConfDir` instead
+of relying on system-wide defaults.
+
 ## Project details
 
 The go-cni is a containerd sub-project, licensed under the [Apache 2.0 license](./LICENSE).


### PR DESCRIPTION
## Summary

This updates the README to explicitly document the built-in default plugin/config directories and add guidance for non-standard environments.

## Changes

- documents default plugin/config directories used when `WithPluginDir` and `WithPluginConfDir` are not provided
- lists defaults for non-Windows and Windows
- adds guidance to explicitly pass directories for rootless or non-standard environments (for example Darwin-based setups)

## Why

The defaults are currently implicit in code and easy to miss. Making them explicit in documentation helps users avoid confusing runtime setup issues when system-wide directories are not present or writable.

## Review request

I would appreciate review from someone familiar with both `go-cni` and real-world runtime setups (including Darwin/rootless environments) to confirm this guidance is accurate and helpful.
