### PR TITLE
Tear down networks in reverse of configured order

### DIFF
--- a/cni.go
+++ b/cni.go
@@ -246,7 +246,9 @@ func (c *libcni) attachNetworks(ctx context.Context, ns *Namespace) ([]*types100
 	return results, firstError
 }
 
-// Remove removes the network config from the namespace
+// Remove removes the network config from the namespace. Networks are torn
+// down in reverse of the order they were configured, as expected by the CNI
+// spec.
 func (c *libcni) Remove(ctx context.Context, id string, path string, opts ...NamespaceOpts) error {
 	c.RLock()
 	defer c.RUnlock()
@@ -257,7 +259,8 @@ func (c *libcni) Remove(ctx context.Context, id string, path string, opts ...Nam
 	if err != nil {
 		return err
 	}
-	for _, network := range c.networks {
+	for i := len(c.networks) - 1; i >= 0; i-- {
+		network := c.networks[i]
 		if err := network.Remove(ctx, ns); err != nil {
 			// Based on CNI spec v0.7.0, empty network namespace is allowed to
 			// do best effort cleanup. However, it is not handled consistently

--- a/cni_test.go
+++ b/cni_test.go
@@ -385,6 +385,51 @@ func TestLibCNIType120(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// TestRemoveReverseOrder verifies that Remove tears down networks in reverse
+// of the order they were configured.
+func TestRemoveReverseOrder(t *testing.T) {
+	t.Parallel()
+
+	l := defaultCNIConfig()
+	_, confDir := buildFakeConfig(t)
+	l.pluginConfDir = confDir
+	l.networkCount = 2
+	err := l.Load(WithLoNetwork, WithDefaultConf)
+	assert.NoError(t, err)
+
+	mockCNI := &MockCNI{}
+	l.networks[0].cni = mockCNI
+	l.networks[1].cni = mockCNI
+
+	loRT := &cnilibrary.RuntimeConf{
+		ContainerID:    "container-id1",
+		NetNS:          "/proc/12345/ns/net",
+		IfName:         "lo",
+		Args:           [][2]string(nil),
+		CapabilityArgs: map[string]interface{}{},
+	}
+	eth0RT := &cnilibrary.RuntimeConf{
+		ContainerID:    "container-id1",
+		NetNS:          "/proc/12345/ns/net",
+		IfName:         "eth0",
+		Args:           [][2]string(nil),
+		CapabilityArgs: map[string]interface{}{},
+	}
+	mockCNI.On("DelNetworkList", l.networks[0].config, loRT).Return(nil)
+	mockCNI.On("DelNetworkList", l.networks[1].config, eth0RT).Return(nil)
+
+	err = l.Remove(context.Background(), "container-id1", "/proc/12345/ns/net")
+	assert.NoError(t, err)
+
+	var ifNames []string
+	for _, c := range mockCNI.Calls {
+		if c.Method == "DelNetworkList" {
+			ifNames = append(ifNames, c.Arguments.Get(1).(*cnilibrary.RuntimeConf).IfName)
+		}
+	}
+	assert.Equal(t, []string{"eth0", "lo"}, ifNames)
+}
+
 func TestLibCNIType120FailStatus(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
`Remove` currently tears down networks in the same order they were configured. This means a config loaded as `WithLoNetwork, WithDefaultConf` runs loopback `DEL` before the user-defined network `DEL`.

The CNI spec tears down plugin chains in reverse order, and the same rule should apply here: networks added earlier should stay available while later networks are being removed. In practice this keeps `lo` up until user-defined plugins have finished their cleanup. This changes `Remove` to iterate `c.networks` in reverse order and adds a regression test for the ordering.

Signed-off-by: ronakj <ronakjainc@gmail.com>
